### PR TITLE
Fix lspconfig setup error

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -570,6 +570,7 @@ require('lazy').setup {
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 
       require('mason-lspconfig').setup {
+        automatic_enable = false,
         handlers = {
           function(server_name)
             local server = servers[server_name] or {}


### PR DESCRIPTION
## Summary
- disable Mason's automatic_enable feature when setting up `mason-lspconfig`
  so `vim.lsp.enable` isn't required

## Testing
- `stylua init.lua`

------
https://chatgpt.com/codex/tasks/task_e_68756bf2b278832d8315550fa1158ec2