### PR TITLE
Use PowerShell (pwsh) for :term on Windows when available

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -112,6 +112,11 @@ vim.opt.showmode = false
 --  See `:help 'clipboard'`
 vim.opt.clipboard = 'unnamedplus'
 
+-- Use PowerShell for :term on Windows when available.
+if (vim.fn.has 'win32' == 1 or vim.fn.has 'win64' == 1) and vim.fn.executable 'pwsh' == 1 then
+  vim.opt.shell = 'pwsh'
+end
+
 -- Enable break indent
 vim.opt.breakindent = true
 


### PR DESCRIPTION
### Motivation
- Ensure `:term` opens PowerShell instead of `cmd.exe` on Windows systems when `pwsh` is installed.

### Description
- Add a conditional in `init.lua` that sets `vim.opt.shell = 'pwsh'` when the platform is Windows (`has 'win32'` or `has 'win64'`) and `pwsh` is executable.

### Testing
- No automated tests were executed for this configuration change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69745eed4ad8832d89f668c7e301b7c4)